### PR TITLE
Add a new file with this gem's name, so bundler will auto-require it.

### DIFF
--- a/lib/ging-opengraph.rb
+++ b/lib/ging-opengraph.rb
@@ -1,0 +1,1 @@
+require File.expand_path("../opengraph", __FILE__)


### PR DESCRIPTION
Currently, if this gem is part of your Gemfile, you will need to manually `require opengraph`. With this change, it will be auto-required in, e.g., the rails console when run via bundler.

I left the gemspec alone, but if you want to merge this, you'll likely want to add this file to the gemspec as well. 
